### PR TITLE
Prefer any lecture hall over Interims

### DIFF
--- a/src/handler.php
+++ b/src/handler.php
@@ -31,7 +31,7 @@ class handler {
         $event->setLocation($location);
 
         //Remove the TAG and anything after e.g.: (IN0001) or [MA0001]
-        $summary = preg_replace('/([\(\[](?:(?:IN|MA|WI)\d+,?\s?)+[\)\]]).+/', '', $summary);
+        $summary = preg_replace('/([(\[](?:(?:IN|MA|WI)\d+,?\s?)+[)\]]).+/', '', $summary);
 
         //remove location and teacher from language course title
         $summary = preg_replace('/(München|Garching|Weihenstephan).+/', '', $summary);

--- a/src/handler.php
+++ b/src/handler.php
@@ -160,11 +160,19 @@ class handler {
             if ($events[$i - 1]->dtstart === $events[$i]->dtstart
                 && $events[$i - 1]->dtend === $events[$i]->dtend
                 && $events[$i - 1]->summary === $events[$i]->summary) {
-                //Append the location to the next (same) element
-                $events[$i]->location .= "\n" . $events[$i - 1]->location;
-
-                //Mark this element for removal
-                unset($events[$i - 1]);
+                //if this and next event are the same, check whether the next is held in interims
+                if (strpos($events[$i]->location, "Interims")) {
+                    //Append the location from the next (same) element to this element
+                    $events[$i - 1]->location .= "\n" . $events[$i]->location;
+                    //Mark next element for removal
+                    unset($events[$i]);
+                    $i--;
+                } else {
+                    //Append the location to the next (same) element
+                    $events[$i]->location .= "\n" . $events[$i - 1]->location;
+                    //Mark this element for removal
+                    unset($events[$i - 1]);
+                }
             }
         }
     }


### PR DESCRIPTION
I'm kind of late to the party concerning #26 but I think this problem is not very hard to solve:

My code just checks whether a duplicate lecture also takes place in the Interims lecture hall and if so, takes the other location.

This would not help with the live-stream to the other campus though. That issue could be tackled by instead of checking for "Interims" in the location using the description and look for "Videoübertragung". Since almost all lectures are streamed right now I think that could lead to many false negatives currently.

**This is just a rough draft, lmk if there is anything that could still be improved :)**