### PR TITLE
Add ML and I2DL to mapping

### DIFF
--- a/src/handler.php
+++ b/src/handler.php
@@ -43,6 +43,7 @@ class handler {
         $searchReplace = [];
         $searchReplace['Tutorübungen'] = 'TÜ';
         $searchReplace['Grundlagen'] = 'G';
+        $searchReplace['Introduction'] = 'I';
         $searchReplace['Datenbanken'] = 'DB';
         $searchReplace['Zentralübungen'] = 'ZÜ';
         $searchReplace['Zentralübung'] = 'ZÜ';
@@ -85,6 +86,8 @@ class handler {
         $searchReplace['Advanced Topics of Software Engineering'] = 'ASE';
         $searchReplace['Praktikum - iPraktikum, iOS Praktikum'] = 'iPraktikum';
         $searchReplace['B1.1+B1.2 (intensiv)'] = 'B1';
+        $searchReplace['Maschinelles Lernen'] = 'ML';
+        $searchReplace[' to Deep Learning'] = 'I2DL';
 
 
         //Do the replacement


### PR DESCRIPTION
With English lectures the "Introduction" should be simply changed to "I" (as it is done with "Grundlagen").

Further, I added two additional lectures attended by a lot of people. 

Probably this mapping should be refactored into a separate json file in the future.