### PR TITLE
Rename second semester modules (GRA/GAD)

### DIFF
--- a/src/courses.json
+++ b/src/courses.json
@@ -32,6 +32,7 @@
   "Grundlagenpraktikum: Rechnerarchitektur": "GRA",
   "Einführung in die Softwaretechnik": "EIST",
   "Grundlagen: Algorithmen und Datenstrukturen": "GAD",
+  "Effiziente Algorithmen und Datenstrukturen": "EAD",
   "Rechnernetze und Verteilte Systeme": "RNVS",
   "Einführung in die Theoretische Informatik": "THEO",
   "Diskrete Strukturen": "DS",

--- a/src/courses.json
+++ b/src/courses.json
@@ -30,7 +30,7 @@
   "Praktikum: Grundlagen der Programmierung": "PGP",
   "Einführung in die Rechnerarchitektur": "ERA",
   "Einführung in die Softwaretechnik": "EIST",
-  "Algorithmen und Datenstrukturen": "AD",
+  "Grundlagen: Algorithmen und Datenstrukturen": "GAD",
   "Rechnernetze und Verteilte Systeme": "RNVS",
   "Einführung in die Theoretische Informatik": "THEO",
   "Diskrete Strukturen": "DS",

--- a/src/courses.json
+++ b/src/courses.json
@@ -27,7 +27,7 @@
   "Bachelor-Seminar: Digitale Hochschule: Aktuelle Trends und Herausforderungen": "Digitale Hochschule",
   "Betriebssysteme und Systemsoftware": "BS",
   "Einführung in die Informatik ": "INFO",
-  "Praktikum: Grundlagen der Programmierung": "PGP",
+  "Praktikum: Grundlagen der Programmierung": "PGdP",
   "Einführung in die Rechnerarchitektur": "ERA",
   "Grundlagenpraktikum: Rechnerarchitektur": "GRA",
   "Einführung in die Softwaretechnik": "EIST",

--- a/src/courses.json
+++ b/src/courses.json
@@ -29,6 +29,7 @@
   "Einführung in die Informatik ": "INFO",
   "Praktikum: Grundlagen der Programmierung": "PGP",
   "Einführung in die Rechnerarchitektur": "ERA",
+  "Grundlagenpraktikum: Rechnerarchitektur": "GRA",
   "Einführung in die Softwaretechnik": "EIST",
   "Grundlagen: Algorithmen und Datenstrukturen": "GAD",
   "Rechnernetze und Verteilte Systeme": "RNVS",


### PR DESCRIPTION
blue: this PR / red: current state
![image](https://user-images.githubusercontent.com/92096842/163355713-365d13e5-90d4-4fea-9926-ce7cf7048e92.png)

This PR renames:
- Grundlagen: Algorithmen und Datenstrukturen to **GAD** from G: AD 
- Grundlagenpraktikum: Rechnerarchitektur to **GRA** from Gpraktikum: Rechnerarchitektur

Due to these changes the calendar is way more readable, especially on mobile devices.