### PR TITLE
Added BWL as a shortcut for Betriebswirtschaftslehre

### DIFF
--- a/src/courses.json
+++ b/src/courses.json
@@ -11,6 +11,7 @@
   "Exercise": "EX",
   "Exercises": "EX",
   "Software Engineering für betriebliche Anwendungen - Bachelorkurs": "SEBA",
+  "Betriebswirtschaftslehre": "BWL",
   "Volkswirtschaftslehre": "VWL",
   "Funktionale Programmierung und Verifikation": "FPV",
   "Buchführung und Rechnungswesen": "BF & RW",


### PR DESCRIPTION
While looking through my current courses, I noticed, that BWL is not supported as a Shortcut, while VWL is.
This PR fixes this