### PR TITLE
Refactored URLs + changed button label

### DIFF
--- a/internal/static/index.html
+++ b/internal/static/index.html
@@ -1,61 +1,103 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta name="viewport" content="width=device-width,
+  <head>
+    <meta
+      name="viewport"
+      content="width=device-width,
     initial-scale=1.0,
     maximum-scale=1.0,
-    user-scalable=no"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css"/>
-    <link rel="stylesheet" href="/files/static/style.css"/>
+    user-scalable=no"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css"
+    />
+    <link rel="stylesheet" href="/files/static/style.css" />
     <script src="/files/static/main.js"></script>
     <title>TUM Calendar Proxy - clean, structured calendar entries</title>
-</head>
-<body>
-<a class="github-fork-ribbon" href="https://github.com/TUM-Dev/CalendarProxy/" data-ribbon="Contribute on GitHub" title="Contribute on GitHub">Contribute on GitHub</a>
-<div class="main">
-    <div class="container-md container">
+  </head>
+  <body>
+    <a
+      class="github-fork-ribbon"
+      href="https://github.com/TUM-Dev/CalendarProxy/"
+      data-ribbon="Contribute on GitHub"
+      title="Contribute on GitHub"
+      >Contribute on GitHub</a
+    >
+    <div class="main">
+      <div class="container-md container">
         <h1>TUM Calendar Proxy</h1>
-        <img src="showcase.png" alt="New and old representation of the calender"/>
+        <img
+          src="showcase.png"
+          alt="New and old representation of the calender"
+        />
 
         <h2>About</h2>
-        <p>Nice and easy proxy to remove some clutter from the TUM online iCal export. E.g.:</p>
+        <p>
+          Nice and easy proxy to remove some clutter from the TUM online iCal
+          export. E.g.:
+        </p>
         <ul>
-            <li>Shorten Lesson Names like 'Grundlagen Betriebssysteme und Systemsoftware' → 'GBS'</li>
-            <li>Adds locations, which are understood by Google Maps / Google Now</li>
-            <li>Replaces 'Tutorübung' with 'TÜ'</li>
-            <li>Remove event duplicates due to multiple rooms</li>
+          <li>
+            Shorten Lesson Names like 'Grundlagen Betriebssysteme und
+            Systemsoftware' → 'GBS'
+          </li>
+          <li>
+            Adds locations, which are understood by Google Maps / Google Now
+          </li>
+          <li>Replaces 'Tutorübung' with 'TÜ'</li>
+          <li>Remove event duplicates due to multiple rooms</li>
         </ul>
 
         <h2>HowTo</h2>
         <ol>
-            <li>Navigate to your calendar in TUMOnline and grab the URL via the 'Veröffentlichen' button</li>
-            <li>
-                <label for="tumCalLink">Provide your calendar link:</label>
-                <div class="inputWrapper">
-                    <input type="url" id="tumCalLink"
-                           placeholder="https://campus.tum.de/tumonlinej/ws/termin/ical?pStud=abc&pToken=xyz"/>
-                    <button id="generateLinkBtn" onclick="generateLink()">copy</button>
-                </div>
-            </li>
-            <li>???</li>
-            <li>Profit!</li>
-            <li>Go to Google Calendar (or similar) and import the resulting url</li>
+          <li>
+            Navigate to your calendar in TUMOnline and grab the URL via the
+            'Veröffentlichen' button
+          </li>
+          <li>
+            <label for="tumCalLink">Provide your calendar link:</label>
+            <div class="inputWrapper">
+              <input
+                type="url"
+                id="tumCalLink"
+                placeholder="https://campus.tum.de/tumonlinej/ws/termin/ical?pStud=abc&pToken=xyz"
+              />
+              <button id="generateLinkBtn" onclick="generateLink()">
+                Generate & Copy
+              </button>
+            </div>
+          </li>
+          <li>???</li>
+          <li>Profit!</li>
+          <li>
+            Go to Google Calendar (or similar) and import the resulting url
+          </li>
         </ol>
         <i>
-            If step 2 does not work, try to copy 'n' Paste the query string
-            (everything after the ? sign, e.g. "?pStud=ABCDEF&pToken=XYZ") and append it to this url:
-            <a href="#dontclickme">https://cal.bruck.me/</a> so it looks like this:
-            <a href="#dontclickme">https://cal.bruck.me/?pStud=ABCDEF&amp;pToken=XYZ</a>
+          If step 2 does not work, try to copy 'n' Paste the query string
+          (everything after the ? sign, e.g. "?pStud=ABCDEF&pToken=XYZ") and
+          append it to this url:
+          <a href="#dontclickme">https://cal.tum.app/</a> so it looks like this:
+          <a href="#dontclickme"
+            >https://cal.tum.app/?pStud=ABCDEF&amp;pToken=XYZ</a
+          >
         </i>
 
         <h3>Contribute / Suggest</h3>
-        If you want to suggest something create an issue at <a href="https://github.com/TUM-Dev/CalendarProxy/issues">Github</a>
+        If you want to suggest something create an issue at
+        <a href="https://github.com/TUM-Dev/CalendarProxy/issues">Github</a>
 
-        <br/>
-        <br/>
+        <br />
+        <br />
 
-        <span style="font-size:10px;color:#aaa;">Version v2.0 - <a href="https://github.com/TUM-Dev/CalendarProxy/commits/master">Changelog</a></span>
+        <span style="font-size: 10px; color: #aaa"
+          >Version v2.0 -
+          <a href="https://github.com/TUM-Dev/CalendarProxy/commits/master"
+            >Changelog</a
+          ></span
+        >
+      </div>
     </div>
-</div>
-</body>
+  </body>
 </html>

--- a/internal/static/main.js
+++ b/internal/static/main.js
@@ -5,7 +5,7 @@ function generateLink() {
         input.setAttribute("class", "invalid")
         return
     }
-    copyToClipboard(input.value.replace(/https:\/\/campus.tum.de\/tumonlinej\/.{2}\/termin\/ical/i, "https://cal.bruck.me").replace("\t", ""))
+    copyToClipboard(input.value.replace(/https:\/\/campus.tum.de\/tumonlinej\/.{2}\/termin\/ical/i, "https://cal.tum.app").replace("\t", ""))
     let btn = document.getElementById("generateLinkBtn")
     btn.innerText = "copied!"
     btn.setAttribute("style", "background-color: #4CAF50;")


### PR DESCRIPTION
This refactors the URLs displayed on the Web-Page and in the generator util to match the new system, else every generated calendar would still use cal.bruck.me.