### PR TITLE
Conststent replacements

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -191,7 +191,7 @@ func (a *App) getCleanedCalendar(all []byte) (*ics.Calendar, error) {
 
 // matches tags like (IN0001) or [MA2012] and everything after.
 // unfortunate also matches wrong brackets like [MA123) but hey…
-var reTag = regexp.MustCompile(" ?[\\[(](MA|IN|WI|WIB)[0-9]+((_|-|,)[a-zA-Z0-9]+)*[\\])].*")
+var reTag = regexp.MustCompile(" ?[\\[(](ED|MW|SOM|CIT|MA|IN|WI|WIB)[0-9]+((_|-|,)[a-zA-Z0-9]+)*[\\])].*")
 
 // Matches location and teacher from language course title
 var reLoc = regexp.MustCompile(" ?(München|Garching|Weihenstephan).+")

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -23,6 +23,39 @@ func getTestData(t *testing.T, name string) (string, *App) {
 	return string(all), app
 }
 
+func TestReplacement(t *testing.T) {
+	r1 := Replacement{"b", "b"}
+	if r1.isLessThan(&r1) {
+		t.Error("Replacement should not be less than itself")
+		return
+	}
+	if r1.isLessThan(&Replacement{key: "longer key first"}) {
+		t.Error("Replacement should sort longer prefix first")
+		return
+	}
+	if !r1.isLessThan(&Replacement{key: ""}) {
+		t.Error("Replacement should sort longer prefix first")
+		return
+	}
+	if r1.isLessThan(&Replacement{key: "a"}) {
+		t.Error("Replacement should sort alphabetically")
+		return
+	}
+	if !r1.isLessThan(&Replacement{key: "c"}) {
+		t.Error("Replacement should sort alphabetically")
+		return
+	}
+	if r1.isLessThan(&Replacement{key: r1.key, value: "a"}) {
+		t.Error("Replacement with equal key should sort alphabetically by value")
+		return
+	}
+	if !r1.isLessThan(&Replacement{key: r1.key, value: "c"}) {
+		t.Error("Replacement with equal key should sort alphabetically by value")
+		return
+	}
+
+}
+
 func TestDeduplication(t *testing.T) {
 	testData, app := getTestData(t, "duplication.ics")
 	calendar, err := app.getCleanedCalendar([]byte(testData))


### PR DESCRIPTION
This PR makes the replacements not random => repeatable.
Iterating over hashmaps is not something that go actively supports as deterministic operation => this is replaced by a slice

Proof that this works: 
![image](https://github.com/TUM-Dev/CalendarProxy/assets/26258709/d0f8c481-9015-45b7-a259-f74b22844177)

and an unit test