### PR TITLE
Fixed port number on which app is exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ To run the service locally, follow these steps:
 - Clone this repository: `git clone https://github.com/tum-calendar-proxy/tum-calendar-proxy.git`
 - Navigate to the project directory: `cd tum-calendar-proxy`
 - Run the proxy server: `go run cmd/proxy/proxy.go`
-- The service will be available at <http://localhost:8081>
+- The service will be available at <http://localhost:4321>
 
 To build a production image using Docker, follow these steps:
 
 - Build the image: `docker build -t tumcalproxy .`
-- Run the container: `docker run -p 8081:8081 tumcalproxy`
-- The service will be available at <http://localhost:8081>
+- Run the container: `docker run -p 4321:4321 tumcalproxy`
+- The service will be available at <http://localhost:4321>


### PR DESCRIPTION
# Problem
The port specified in the project description does not match the one the app actually exposes in the code.

**Port specified**: 8021
**Port exposed in code**:
![grafik](https://github.com/TUM-Dev/CalendarProxy/assets/9247500/54b35d9b-2264-44db-bace-53fe83315706)
`internal/app.go:100`

# Why is this useful
Making sure the documentation is up-to-date enables people to make tangible additions to this project and reduces potential contributers bounce rate.
