### PR TITLE
Add navigatum link to description

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -263,9 +263,9 @@ func (a *App) cleanEvent(event *ics.VEvent) {
 			description = location + "\n" + description
 			event.SetLocation(building)
 		}
-		if navigaTUMURL := reNavigaTUM.FindString(location); navigaTUMURL != "" {
-			navigaTUMURL = strings.Trim(navigaTUMURL, "()")
-			navigaTUMURL = fmt.Sprintf("https://nav.tum.de/view/%s", navigaTUMURL)
+		if roomID := reNavigaTUM.FindString(location); roomID != "" {
+			roomID = strings.Trim(navigaTUMURL, "()")
+			description = fmt.Sprintf("https://nav.tum.de/room/%s\n%s", roomID, description)
 			description = navigaTUMURL + "\n" + description
 		}
 	}

--- a/internal/app.go
+++ b/internal/app.go
@@ -264,9 +264,8 @@ func (a *App) cleanEvent(event *ics.VEvent) {
 			event.SetLocation(building)
 		}
 		if roomID := reNavigaTUM.FindString(location); roomID != "" {
-			roomID = strings.Trim(navigaTUMURL, "()")
+			roomID = strings.Trim(roomID, "()")
 			description = fmt.Sprintf("https://nav.tum.de/room/%s\n%s", roomID, description)
-			description = navigaTUMURL + "\n" + description
 		}
 	}
 	event.SetDescription(description)

--- a/internal/app.go
+++ b/internal/app.go
@@ -224,6 +224,9 @@ var unneeded = []string{
 
 var reRoom = regexp.MustCompile("^(.*?),.*(\\d{4})\\.(?:\\d\\d|EG|UG|DG|Z\\d|U\\d)\\.\\d+")
 
+// matches strings like: (5612.03.017), (5612.EG.017), (5612.EG.010B)
+var reNavigaTUM = regexp.MustCompile("\\(\\d{4}\\.[a-zA-Z0-9]{2}\\.\\d{3}[A-Z]?\\)")
+
 func (a *App) cleanEvent(event *ics.VEvent) {
 	summary := ""
 	if s := event.GetProperty(ics.ComponentPropertySummary); s != nil {
@@ -259,6 +262,11 @@ func (a *App) cleanEvent(event *ics.VEvent) {
 		if building, ok := a.buildingReplacements[results[2]]; ok {
 			description = location + "\n" + description
 			event.SetLocation(building)
+		}
+		if navigaTUMURL := reNavigaTUM.FindString(location); navigaTUMURL != "" {
+			navigaTUMURL = strings.Trim(navigaTUMURL, "()")
+			navigaTUMURL = fmt.Sprintf("https://nav.tum.de/view/%s", navigaTUMURL)
+			description = navigaTUMURL + "\n" + description
 		}
 	}
 	event.SetDescription(description)

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -97,7 +97,7 @@ func TestLocationReplacement(t *testing.T) {
 		return
 	}
 	desc := calendar.Components[0].(*ics.VEvent).GetProperty(ics.ComponentPropertyDescription).Value
-	expectedDescription := "https://nav.tum.de/view/5508.02.801\\nMW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801)\\nEinführung in die Rechnerarchitektur\\nfix\\; Abhaltung\\;"
+	expectedDescription := "https://nav.tum.de/room/5508.02.801\\nMW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801)\\nEinführung in die Rechnerarchitektur\\nfix\\; Abhaltung\\;"
 	if desc != expectedDescription {
 		t.Errorf("Description should be %s but is %s", expectedDescription, desc)
 		return

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -91,13 +91,15 @@ func TestLocationReplacement(t *testing.T) {
 		return
 	}
 	location := calendar.Components[0].(*ics.VEvent).GetProperty(ics.ComponentPropertyLocation).Value
-	if location != "Boltzmannstr. 15\\, 85748 Garching b. München" {
-		t.Errorf("MW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801) should be shortened to Boltzmannstr. 15\\, 85748 Garching b. München but is %s", location)
+	expectedLocation := "Boltzmannstr. 15\\, 85748 Garching b. München"
+	if location != expectedLocation {
+		t.Errorf("Location should be shortened to %s but is %s", expectedLocation, location)
 		return
 	}
 	desc := calendar.Components[0].(*ics.VEvent).GetProperty(ics.ComponentPropertyDescription).Value
-	if desc != "MW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801)\\nEinführung in die Rechnerarchitektur\\nfix\\; Abhaltung\\;" {
-		t.Errorf("Description should be MW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801)\\nEinführung in die Rechnerarchitektur\\nfix\\; Abhaltung\\; but is %s", desc)
+	expectedDescription := "https://nav.tum.de/view/5508.02.801\\nMW 1801\\, Ernst-Schmidt-Hörsaal (5508.02.801)\\nEinführung in die Rechnerarchitektur\\nfix\\; Abhaltung\\;"
+	if desc != expectedDescription {
+		t.Errorf("Description should be %s but is %s", expectedDescription, desc)
 		return
 	}
 }


### PR DESCRIPTION
This is a proposed solution that resolves #165.

- Adds a regex that matches exactly the pattern that all roomcodes at tum share (like: (5612.03.017), (5612.EG.017), (5612.EG.010B)) which are used for navigaTUM URLs.
- improves readability of location tests

I did some local tests and manually checked some additional ICS files generated with the proposed changes additionally and it all looked fine, but i would love it if someone else could build this proposal locally and also do a quick check. 

Im was undecided if the roomcode should be removed from the description whenever we add a navigatum link but for now i decided to keep it.

Im quite new to Go so i hope i did everything fairly alright :)
